### PR TITLE
Fix failing tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,61 +1,60 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-	<groupId>ca.vgorcinschi</groupId>
-	<artifactId>AssignmentThree</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
-	<packaging>jar</packaging>
+    <groupId>ca.vgorcinschi</groupId>
+    <artifactId>AssignmentThree</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
 
-	<name>AssignmentThree</name>
-	<description>Demo project for Spring Boot</description>
+    <name>AssignmentThree</name>
+    <description>Demo project for Spring Boot</description>
 
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.4.1.RELEASE</version>
-		<relativePath/> <!-- lookup parent from repository -->
-	</parent>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>1.4.1.RELEASE</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
 
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<java.version>1.8</java.version>
-                <start-class>ca.vgorcinschi.App</start-class>
-	</properties>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <java.version>1.8</java.version>
+        <start-class>ca.vgorcinschi.App</start-class>
+    </properties>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-jdbc</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
-			<scope>runtime</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	 <dependency>
-	  <groupId>org.apache.commons</groupId>
-	  <artifactId>commons-lang3</artifactId>
-	  <version>3.4</version>
-	  <type>jar</type>
-	 </dependency>
-	</dependencies>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.4</version>
+        </dependency>
+    </dependencies>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 
 
 </project>

--- a/src/main/java/ca/vgorcinschi/App.java
+++ b/src/main/java/ca/vgorcinschi/App.java
@@ -6,32 +6,30 @@ import javafx.stage.Stage;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Lazy;
 
 @SpringBootApplication
-@Lazy
-public class App extends AbstractJavaFxApplicationSupport{
+public class App extends AbstractJavaFxApplicationSupport {
 
-	/**
-	 * Note that this is configured in application.properties
-	 */
-	@Value("${app.ui.title:Example App}")//
-	private String windowTitle;
-        
-        @Autowired//
-	private MainLayout mainLayout;
+    /**
+     * Note that this is configured in application.properties
+     */
+    @Value("${app.ui.title:Example App}")//
+    private String windowTitle;
 
-	@Override
-	public void start(Stage stage) throws Exception {
+    @Autowired//
+    private MainLayout mainLayout;
 
-		stage.setTitle(windowTitle);
-		stage.setScene(new Scene(mainLayout));
-		stage.setResizable(true);
-		stage.centerOnScreen();
-		stage.show();
-	}
+    @Override
+    public void start(Stage stage) throws Exception {
 
-	public static void main(String[] args) {
-		launchApp(App.class, args);
-	}
+        stage.setTitle(windowTitle);
+        stage.setScene(new Scene(mainLayout));
+        stage.setResizable(true);
+        stage.centerOnScreen();
+        stage.show();
+    }
+
+    public static void main(String[] args) {
+        launchApp(App.class, args);
+    }
 }

--- a/src/main/java/ca/vgorcinschi/ui/HelloWorldComponent.java
+++ b/src/main/java/ca/vgorcinschi/ui/HelloWorldComponent.java
@@ -17,7 +17,6 @@ package ca.vgorcinschi.ui;
 
 import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
-
 import org.springframework.stereotype.Component;
 
 /**
@@ -26,7 +25,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class HelloWorldComponent extends HBox {
 
-	public HelloWorldComponent() {
-		getChildren().add(new Label("Hello World"));
-	}
+    public HelloWorldComponent() {
+        getChildren().add(new Label("Hello World"));
+    }
 }

--- a/src/main/java/ca/vgorcinschi/ui/MainLayout.java
+++ b/src/main/java/ca/vgorcinschi/ui/MainLayout.java
@@ -16,7 +16,6 @@
 package ca.vgorcinschi.ui;
 
 import javafx.scene.layout.GridPane;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -26,22 +25,22 @@ import org.springframework.stereotype.Component;
 @Component
 public class MainLayout extends GridPane {
 
-	private final HelloWorldComponent helloWorldComponent;
+    private final HelloWorldComponent helloWorldComponent;
 
-	private final SinChartComponent sinChartComponent;
+    private final SinChartComponent sinChartComponent;
 
-	@Autowired
-	public MainLayout(HelloWorldComponent helloWorldComponent, SinChartComponent sinChartComponent) {
+    @Autowired
+    public MainLayout(HelloWorldComponent helloWorldComponent, SinChartComponent sinChartComponent) {
 
-		this.helloWorldComponent = helloWorldComponent;
-		this.sinChartComponent = sinChartComponent;
+        this.helloWorldComponent = helloWorldComponent;
+        this.sinChartComponent = sinChartComponent;
 
-		initComponent();
-	}
+        initComponent();
+    }
 
-	private void initComponent() {
+    private void initComponent() {
 
-		add(this.helloWorldComponent, 0, 0);
-		add(this.sinChartComponent, 0, 1);
-	}
+        add(this.helloWorldComponent, 0, 0);
+        add(this.sinChartComponent, 0, 1);
+    }
 }

--- a/src/main/java/ca/vgorcinschi/ui/SinChartComponent.java
+++ b/src/main/java/ca/vgorcinschi/ui/SinChartComponent.java
@@ -20,7 +20,6 @@ import javafx.scene.chart.LineChart;
 import javafx.scene.chart.NumberAxis;
 import javafx.scene.chart.XYChart;
 import javafx.scene.layout.HBox;
-
 import org.springframework.stereotype.Component;
 
 /**
@@ -29,27 +28,27 @@ import org.springframework.stereotype.Component;
 @Component
 public class SinChartComponent extends HBox {
 
-	public SinChartComponent() {
+    public SinChartComponent() {
 
-		NumberAxis xAxis = new NumberAxis();
-		xAxis.setLabel("x");
+        NumberAxis xAxis = new NumberAxis();
+        xAxis.setLabel("x");
 
-		NumberAxis yAxis = new NumberAxis();
-		yAxis.setLabel("y");
+        NumberAxis yAxis = new NumberAxis();
+        yAxis.setLabel("y");
 
-		XYChart.Series<Number, Number> series = new XYChart.Series<>();
-		series.setName("Sine");
+        XYChart.Series<Number, Number> series = new XYChart.Series<>();
+        series.setName("Sine");
 
-		ObservableList<XYChart.Data<Number, Number>> data = series.getData();
+        ObservableList<XYChart.Data<Number, Number>> data = series.getData();
 
-		for (double x = -Math.PI; x < Math.PI; x += 0.5) {
-			data.add(new XYChart.Data<Number, Number>(x, 10 * Math.sin(x)));
-		}
+        for (double x = -Math.PI; x < Math.PI; x += 0.5) {
+            data.add(new XYChart.Data<Number, Number>(x, 10 * Math.sin(x)));
+        }
 
-		LineChart<Number, Number> lineChart = new LineChart<Number, Number>(xAxis, yAxis);
-		lineChart.setTitle("Sine function");
-		lineChart.getData().add(series);
+        LineChart<Number, Number> lineChart = new LineChart<Number, Number>(xAxis, yAxis);
+        lineChart.setTitle("Sine function");
+        lineChart.getData().add(series);
 
-		getChildren().add(lineChart);
-	}
+        getChildren().add(lineChart);
+    }
 }

--- a/src/test/java/ca/vgorcinschi/IntegrationTestConfig.java
+++ b/src/test/java/ca/vgorcinschi/IntegrationTestConfig.java
@@ -1,0 +1,13 @@
+package ca.vgorcinschi;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+
+@ComponentScan(excludeFilters = {
+        @ComponentScan.Filter(pattern="ca\\.vgorcinschi\\.ui.*", type = FilterType.REGEX),
+        @ComponentScan.Filter(classes = App.class, type = FilterType.ASSIGNABLE_TYPE)
+})
+@SpringBootApplication(exclude = App.class)
+public class IntegrationTestConfig {
+}

--- a/src/test/java/ca/vgorcinschi/JavaFxRuntimeAvailable.java
+++ b/src/test/java/ca/vgorcinschi/JavaFxRuntimeAvailable.java
@@ -1,0 +1,35 @@
+package ca.vgorcinschi;
+
+import javafx.embed.swing.JFXPanel;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class JavaFxRuntimeAvailable implements TestRule {
+
+    private static final AtomicBoolean JAVA_FX_STARTED = new AtomicBoolean(false);
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+
+                if (!JAVA_FX_STARTED.get()) {
+                    initializeJavaFxRuntime();
+                    JAVA_FX_STARTED.set(true);
+                }
+
+                base.evaluate();
+            }
+        };
+    }
+
+    private void initializeJavaFxRuntime() {
+        //implicitly initializes JavaFX Subsystem
+        // see http://stackoverflow.com/questions/14025718/javafx-toolkit-not-initialized-when-trying-to-play-an-mp3-file-through-mediap
+        new JFXPanel();
+    }
+}

--- a/src/test/java/ca/vgorcinschi/PatientDbApplicationTests.java
+++ b/src/test/java/ca/vgorcinschi/PatientDbApplicationTests.java
@@ -1,42 +1,63 @@
 package ca.vgorcinschi;
 
-import javax.sql.DataSource;
-import static org.junit.Assert.*;
+import javafx.application.Application;
+import javafx.embed.swing.JFXPanel;
+import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import javax.sql.DataSource;
+
+import static org.junit.Assert.assertNotNull;
+
 @RunWith(SpringRunner.class)
-@SpringBootTest
+@ComponentScan(excludeFilters = {
+        @ComponentScan.Filter(classes = IntegrationTestConfig.class, type = FilterType.ASSIGNABLE_TYPE)
+})
+@SpringBootTest(classes = App.class)
 public class PatientDbApplicationTests {
+
+    @Rule
+    public JavaFxRuntimeAvailable javaFxRuntimeAvailable = new JavaFxRuntimeAvailable();
 
     /**
      * DataSource is configured in the src/main/resources/application.yml
      */
     @Autowired
     private DataSource dataSource;
-    
+
     /**
      * We don't even have to configure JdbcTemplate as a Bean. In Spring Boot
      * it is defined in the DataSourceAutoConfiguration class
      */
     @Autowired
     private JdbcTemplate jdbcTemplate;
-    
-	@Test
-	public void contextLoads() {
-	}
-        
-        @Test
-        public void dataSourceIsNotNullTest(){
-            assertNotNull(dataSource);
-        }
 
-        @Test
-        public void jdbcTemplateIsNotNull(){
-            assertNotNull(jdbcTemplate);
-        }
+    @BeforeClass
+    public static void bootstrapJavaFx(){
+        //implicitly initializes JavaFX Subsystem
+        // see http://stackoverflow.com/questions/14025718/javafx-toolkit-not-initialized-when-trying-to-play-an-mp3-file-through-mediap
+        new JFXPanel();
+    }
+
+    @Test
+    public void contextLoads() {
+    }
+
+    @Test
+    public void dataSourceIsNotNullTest() {
+        assertNotNull(dataSource);
+    }
+
+    @Test
+    public void jdbcTemplateIsNotNull() {
+        assertNotNull(jdbcTemplate);
+    }
 }

--- a/src/test/java/ca/vgorcinschi/dao/PatientDBServiceTests.java
+++ b/src/test/java/ca/vgorcinschi/dao/PatientDBServiceTests.java
@@ -1,19 +1,13 @@
 package ca.vgorcinschi.dao;
 
+import ca.vgorcinschi.IntegrationTestConfig;
 import ca.vgorcinschi.dao.repositories.MedicationRepository;
 import ca.vgorcinschi.dao.repositories.PatientRepository;
 import ca.vgorcinschi.model.Identifiable;
 import ca.vgorcinschi.model.Medication;
 import ca.vgorcinschi.model.Patient;
-import static java.math.BigDecimal.valueOf;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.Random;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.After;
-import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -22,13 +16,24 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+
+import static java.math.BigDecimal.valueOf;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 /**
  * Test class to test the jdbc implementation for PatientDBService
  *
  * @author vgorcinschi
  */
 @RunWith(SpringRunner.class)
-@SpringBootTest
+@SpringBootTest(classes = IntegrationTestConfig.class)
 public class PatientDBServiceTests {
 
     @Autowired


### PR DESCRIPTION
Introduced a dedicated IntegrationTestConfig for service / data access
layer tests which excludes the JavaFX UI components.

Previously the tests failed because the SpringBoot test environment
tried to instantiate the UI application components within a test run
in a different order than when run as a standalone app.
In that case the JavaFX runtime was not bootstrapped yet when spring
tried to construct UI component instances discovered via
component-scanning.

I also introduced a JUnit 4 rule to mark test classes which require
the JavaFX environment to initialized.

This is just a workaround - a better solution would be to split
the application into two modules:
a *javafx-client*-module with the javafx frontend and a *app*-module.
The app module would contain your core business logic with services
and repositories.
The client module would then just use the service module.
Client and Business Logic could then be tested independently.
For the app-module you could have a SpringBoot bootstrap in the
test package just for that layer.